### PR TITLE
Add Nginx service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN composer install --no-interaction --prefer-dist \
     && npm install \
     && npm run build
 
-CMD ["php", "artisan", "serve", "--host=0.0.0.0", "--port=8000"]
+CMD ["php-fpm"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ docker-compose up -d
 ```
 
 Visit http://localhost:8000 to access the app.
+The `web` service runs Nginx in front of the PHP-FPM container.
 
 PrimeVue 4 and PrimeIcons are included via Vite. See `resources/js/app.js` for an example setup.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '3.8'
 services:
   app:
     build: .
-    ports:
-      - "8000:8000"
     volumes:
       - ./laravel:/var/www/html
     environment:
@@ -13,6 +11,15 @@ services:
       DB_PASSWORD: secret
     depends_on:
       - db
+  web:
+    image: nginx:latest
+    ports:
+      - "8000:80"
+    volumes:
+      - ./laravel:/var/www/html
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - app
   db:
     image: mysql:8.0
     environment:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    index index.php index.html;
+    root /var/www/html/public;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        fastcgi_buffers 16 16k;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}


### PR DESCRIPTION
## Summary
- run PHP-FPM instead of the built-in web server
- add an Nginx container with a basic config
- expose the web server through port 8000
- document the Nginx setup in the README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edac316488329b978954ea957cfc4